### PR TITLE
fix logical operator and sleep

### DIFF
--- a/lib/shopify_api_extensions/backoff.rb
+++ b/lib/shopify_api_extensions/backoff.rb
@@ -29,7 +29,7 @@ ShopifyAPI::Connection.class_eval do
       end
 
       # TODO look at code instead of static string? This is brittle
-      if e.class == ActiveResource::ClientError && e.message != "Failed.  Response code = 429.  Response message = Too Many Requests."
+      if e.class == ActiveResource::ClientError && e.message == "Failed.  Response code = 429.  Response message = Too Many Requests."
         if rate_limit_retry > 0 && rate_limit_retry % 10 == 0
           puts "Shopify Rate Limit Error Encountered"
         end
@@ -38,7 +38,7 @@ ShopifyAPI::Connection.class_eval do
           raise
         else
           rate_limit_retry += 1
-          count(rate_limit_retry)
+          sleep(rate_limit_retry)
           retry
         end
       elsif e.class == ActiveResource::ClientError


### PR DESCRIPTION
So the problem wasn't a change in the string from Shopify's end, it was that the logic is backwards which caused it to skip this block upon the 'Too Many Requests' message. Then when the logic was fixed, the `count` was tripping up so I replaced it with `sleep` like the block below that. This worked when I tested it in Ledbury Staging