### PR TITLE
Backoff on ActiveResource::TimeoutError

### DIFF
--- a/lib/shopify_api_extensions/backoff.rb
+++ b/lib/shopify_api_extensions/backoff.rb
@@ -22,7 +22,7 @@ ShopifyAPI::Connection.class_eval do
         ActiveResource::SSLError,
         ActiveResource::TimeoutError,
         # NOTE represents only 500x errors
-        ActiveResource::ServerError,
+        ActiveResource::ServerError
       ]
 
       if !exceptions_to_retry.include?(e.class)

--- a/lib/shopify_api_extensions/backoff.rb
+++ b/lib/shopify_api_extensions/backoff.rb
@@ -20,8 +20,9 @@ ShopifyAPI::Connection.class_eval do
         Zlib::BufError,
         SocketError,
         ActiveResource::SSLError,
+        ActiveResource::TimeoutError,
         # NOTE represents only 500x errors
-        ActiveResource::ServerError
+        ActiveResource::ServerError,
       ]
 
       if !exceptions_to_retry.include?(e.class)


### PR DESCRIPTION
Added ActiveResource::TimeoutError to list of errors to backoff from.

I think this should be included in the list of errors that are handled and backed off from.